### PR TITLE
Gpriest/tutorial javaupdate

### DIFF
--- a/.project/spec.yaml
+++ b/.project/spec.yaml
@@ -23,8 +23,8 @@ layout:
 environment:
     base:
         registry: nvcr.io
-        image: nvidia/ai-workbench/python-basic:1.0.2
-        build_timestamp: "20241001182612"
+        image: nvidia/ai-workbench/python-basic:1.0.6
+        build_timestamp: "20250205043314"
         name: Python Basic
         supported_architectures: []
         cuda_version: ""
@@ -35,26 +35,6 @@ environment:
             - python3
             - jupyterlab
         apps:
-            - name: Tutorial
-              type: custom
-              class: webapp
-              start_command: |
-                cd /project/code/tutorial_app && \
-                export PROXY_PREFIX && \
-                streamlit run streamlit_app.py --server.baseUrlPath=$PROXY_PREFIX
-              health_check_command: curl -I http://localhost:8501
-              stop_command: |
-                pkill -f 'streamlit run streamlit_app.py'
-              user_msg: ""
-              logfile_path: ""
-              timeout_seconds: 30
-              icon_url: ""
-              webapp_options:
-                autolaunch: true
-                port: "8501"
-                proxy:
-                    trim_prefix: false
-                url: http://localhost:8501
             - name: jupyterlab
               type: jupyterlab
               class: webapp
@@ -74,7 +54,7 @@ environment:
         programming_languages:
             - python3
         icon_url: https://workbench.download.nvidia.com/static/img/ai-workbench-icon-rectangle.jpg
-        image_version: 1.0.5
+        image_version: 1.0.6
         os: linux
         os_distro: ubuntu
         os_distro_release: "22.04"
@@ -98,7 +78,7 @@ environment:
             - name: pip
               binary_path: /usr/bin/pip
               installed_packages:
-                - jupyterlab==4.2.4
+                - jupyterlab==4.2.5
         package_manager_environment:
             name: ""
             target: ""

--- a/.project/spec.yaml
+++ b/.project/spec.yaml
@@ -23,8 +23,8 @@ layout:
 environment:
     base:
         registry: nvcr.io
-        image: nvidia/ai-workbench/python-basic:1.0.6
-        build_timestamp: "20250205043314"
+        image: nvidia/ai-workbench/python-basic:1.0.2
+        build_timestamp: "20241001182612"
         name: Python Basic
         supported_architectures: []
         cuda_version: ""
@@ -35,6 +35,26 @@ environment:
             - python3
             - jupyterlab
         apps:
+         - name: Tutorial
+              type: custom
+              class: webapp
+              start_command: |
+                cd /project/code/tutorial_app && \
+                export PROXY_PREFIX && \
+                streamlit run streamlit_app.py --server.baseUrlPath=$PROXY_PREFIX
+              health_check_command: curl -I http://localhost:8501
+              stop_command: |
+                pkill -f 'streamlit run streamlit_app.py'
+              user_msg: ""
+              logfile_path: ""
+              timeout_seconds: 30
+              icon_url: ""
+              webapp_options:
+                autolaunch: true
+                port: "8501"
+                proxy:
+                    trim_prefix: false
+                url: http://localhost:8501
             - name: jupyterlab
               type: jupyterlab
               class: webapp


### PR DESCRIPTION
[copied from email]
Okay, I know why the button is gone. 

Looking at the PR diff, for some reason AI Workbench deleted the following code deleting the app altogether.

If I stick this code back in manually, it should come back.

![image](https://github.com/user-attachments/assets/0a579faa-d6c4-4917-a8a1-d4b42f089c7f)

 

This is a serious bug with the application, and someone needs to look into this and fix. Who should this be escalated to?
